### PR TITLE
List failed test in XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A *testplan* is a collection of *tests* to be run. The different tests inside wi
 - *maxIMAQiterations*: (Only for functional tests) Maximum counter for the image test. Optional, default to *65536*.
 - *results*: Field to store the count of passed tests. Should not be written by the user.
 - *summary*: Field to store the string result of the test. Either *PASS* or *FAIL*. Should not be written by the user.
+- *failedTests*: List of the names of the failed tests. Should not be written by the user.
 
 Once the test is defined on the XML file, from the root of the project, run:
 ```bash

--- a/src/main/doc/mainPage.dox
+++ b/src/main/doc/mainPage.dox
@@ -199,6 +199,7 @@ Each test contains the following fields:
 - *maxIMAQiterations*: (Only for functional tests) Maximum counter for the image test. Optional, default to *65536*.
 - *results*: Field to store the count of passed tests. Should not be written by the user.
 - *summary*: Field to store the string result of the test. Either *PASS* or *FAIL*. Should not be written by the user.
+- *failedTests*: List of the names of the failed tests. Should not be written by the user.
 
 Once the test is defined on the XML file, from the root of the project, run:
 ```bash

--- a/src/test/automate_GT.py
+++ b/src/test/automate_GT.py
@@ -242,5 +242,16 @@ else:
             summaryElement.appendChild(tree.createTextNode("PASS" if passed_bool else "FAIL"))
             test.appendChild(summaryElement)
 
+        failedTestsElement = test.getElementsByTagName("failedTests")
+        if failedTestsElement:
+            failedTestsElement[0].parentNode.removeChild(failedTestsElement[0])
+
+        failedTestsElement = tree.createElement("failedTests")
+        for failed_test in failed_tests:
+            failedTestElement = tree.createElement("testName")
+            failedTestElement.appendChild(tree.createTextNode(failed_test))
+            failedTestsElement.appendChild(failedTestElement)
+        test.appendChild(failedTestsElement)
+
     with open(targetFile, 'wt') as fd:
         fd.write("".join([s for s in tree.toprettyxml().strip().splitlines(True) if s.strip("\r\n").strip()]))

--- a/src/test/automate_GT.py
+++ b/src/test/automate_GT.py
@@ -30,7 +30,7 @@ def searchSerial(device, order):
     else:
         return results[max(min(int(order) - 1, len(results) - 1), 0)]
 
-def runCommand(binary, filterText, RIODevice, RIOSerial, Verbose, Coupling, MaxCounter, Summary=False):
+def runCommand(suiteName, binary, filterText, RIODevice, RIOSerial, Verbose, Coupling, MaxCounter, Summary=False):
     cwd = os.getcwd()
     os.chdir(os.path.dirname(binary))
 
@@ -49,6 +49,7 @@ env -S Coupling={Coupling} \
 env -S maxCounter={MaxCounter} \
     ./{os.path.basename(binary)} --gtest_filter={filterText}" 
 
+    print('\n' + (' ' + suiteName + ' ').center(80, '='))
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, bufsize=1)
     while True:
         line = process.stdout.readline()
@@ -200,10 +201,7 @@ else:
             print("Malformatted test in XML, omitting it")
             continue
         
-        if summary: 
-            print(f"Running test \"{testName}\"")
-
-        result = runCommand(binary, filterText, RIODevice, RIOSerial, verbose, coupling, maxIterations, summary)
+        result = runCommand(testName, binary, filterText, RIODevice, RIOSerial, verbose, coupling, maxIterations, summary)
 
         if summary:
             pass_word = "\033[32mPASS\033[00m"

--- a/src/test/testSchema.xsd
+++ b/src/test/testSchema.xsd
@@ -62,6 +62,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:complexType name="failedTestsType">
+        <xs:sequence>
+            <xs:element name="testName" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:complexType name="testType">
         <xs:all>
             <xs:element name="name"              type="xs:string"/>
@@ -70,11 +76,12 @@
             <xs:element name="RIODevice"         type="RIODeviceType"/>
             <xs:element name="RIOSerial"         type="RIOSerialType"/>
             <xs:element name="RIOModule"         type="moduleType" />
-            <xs:element name="verbose"           type="xs:boolean"     minOccurs="0"/>
-            <xs:element name="coupling"          type="couplingType"   minOccurs="0"/>
-            <xs:element name="maxIMAQiterations" type="xs:unsignedInt" minOccurs="0"/>
-            <xs:element name="results"           type="resultsType"    minOccurs="0"/>
-            <xs:element name="summary"           type="summaryType"    minOccurs="0"/>
+            <xs:element name="verbose"           type="xs:boolean"      minOccurs="0"/>
+            <xs:element name="coupling"          type="couplingType"    minOccurs="0"/>
+            <xs:element name="maxIMAQiterations" type="xs:unsignedInt"  minOccurs="0"/>
+            <xs:element name="results"           type="resultsType"     minOccurs="0"/>
+            <xs:element name="summary"           type="summaryType"     minOccurs="0"/>
+            <xs:element name="failedTests"       type="failedTestsType" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 
@@ -85,6 +92,5 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-
 
 </xs:schema>


### PR DESCRIPTION
When test failed, the output XML only reported the number of test that passed. Now, it adds a new field, "failedTests", which lists all the names of the tests that have failed.