### PR TITLE
Add feature to specify DMA depth

### DIFF
--- a/src/main/c++/irioCoreCpp/include/terminals/impl/terminalsDMACommonImpl.h
+++ b/src/main/c++/irioCoreCpp/include/terminals/impl/terminalsDMACommonImpl.h
@@ -74,9 +74,9 @@ class TerminalsDMACommonImpl: public TerminalsBaseImpl{
 
 	std::vector<std::uint8_t> getAllSampleSizesImpl() const;
 
-	void startDMAImpl(const std::uint32_t n) const;
+	void startDMAImpl(const std::uint32_t n, const size_t depth) const;
 
-	void startAllDMAsImpl() const;
+	void startAllDMAsImpl(const size_t depth) const;
 
 	void stopDMAImpl(const std::uint32_t n) const;
 
@@ -124,11 +124,9 @@ class TerminalsDMACommonImpl: public TerminalsBaseImpl{
 	std::unordered_map<std::uint32_t, const std::uint32_t> getDMAMap() const;
 
  private:
-	static const size_t SIZE_HOST_DMAS = 2048000;  // TODO: Why this number?
-
 	std::unordered_map<std::uint32_t, const std::uint32_t> m_mapDMA;
 
-	void startDMACommon(const std::uint32_t &dma) const;
+	void startDMACommon(const std::uint32_t &dma, const size_t depth) const;
 	void cleanDMACommon(const std::uint32_t &dma) const;
 
 	std::uint32_t m_overflowsAddr;

--- a/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
+++ b/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
@@ -291,6 +291,7 @@ class TerminalsDMACommon: public TerminalsBase{
 	/**
 	* Default depth for DMA. In number of elements.
 	*/
-	static const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;  // TODO: Why this number?
+	static const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;
+	// TODO: Why this number?
 };
 }  // namespace irio

--- a/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
+++ b/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
@@ -10,6 +10,9 @@ namespace irio {
 
 class TerminalsDMACommonImpl;
 
+/**
+ * Default depth for DMA. In number of elements.
+ */
 const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;  // TODO: Why this number?
 
 /**

--- a/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
+++ b/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
@@ -10,6 +10,8 @@ namespace irio {
 
 class TerminalsDMACommonImpl;
 
+const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;  // TODO: Why this number?
+
 /**
  * Class managing the terminals common to all other
  * terminals that use DMAs in the RIO device
@@ -103,16 +105,19 @@ class TerminalsDMACommon: public TerminalsBase{
 	 * @throw irio::errors::NiFpgaError Error occurred in an FPGA operation
 	 *
 	 * @param n DMA group to configure and start
+	 * @param depth DMA depth to configure DMA
 	 */
-	void startDMA(const std::uint32_t n) const;
+	void startDMA(const std::uint32_t n,
+			const size_t depth = SIZE_HOST_DMAS_DEFAULT) const;
 
 	/**
 	 * Configures and starts all DMAs in the FPGA
 	 *
 	 * @throw irio::errors::NiFpgaError Error occurred in an FPGA operation
 	 *
+	 * @param depth DMA depth to configure all DMAs
 	 */
-	void startAllDMAs() const;
+	void startAllDMAs(const size_t depth = SIZE_HOST_DMAS_DEFAULT) const;
 
 	/**
 	 * Stops the specified DMA group

--- a/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
+++ b/src/main/c++/irioCoreCpp/include/terminals/terminalsDMACommon.h
@@ -11,11 +11,6 @@ namespace irio {
 class TerminalsDMACommonImpl;
 
 /**
- * Default depth for DMA. In number of elements.
- */
-const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;  // TODO: Why this number?
-
-/**
  * Class managing the terminals common to all other
  * terminals that use DMAs in the RIO device
  *
@@ -292,5 +287,10 @@ class TerminalsDMACommon: public TerminalsBase{
 	 * @return Number of found DMAs
 	 */
 	size_t countDMAs() const;
+
+	/**
+	* Default depth for DMA. In number of elements.
+	*/
+	static const size_t SIZE_HOST_DMAS_DEFAULT = 2048000;  // TODO: Why this number?
 };
 }  // namespace irio

--- a/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
+++ b/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
@@ -106,7 +106,7 @@ void TerminalsDMACommonImpl::startDMACommon(const std::uint32_t &dma,
 		const size_t depth) const {
 	auto status = NiFpga_ConfigureFifo(m_session, dma, depth);
 	utils::throwIfNotSuccessNiFpga(status,
-			"Error configuring " + m_nameTermDMA + std::to_string(dma) 
+			"Error configuring " + m_nameTermDMA + std::to_string(dma)
 			+ " with depth " + std::to_string(depth));
 	status = NiFpga_StartFifo(m_session, dma);
 	utils::throwIfNotSuccessNiFpga(status,

--- a/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
+++ b/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
@@ -168,7 +168,7 @@ void TerminalsDMACommonImpl::cleanDMACommon(const std::uint32_t &dma) const {
 			"Error reading " + m_nameTermDMA + std::to_string(dma));
 
 	// TODO: Find better way?
-	static const size_t sizeCleanBuffer = SIZE_HOST_DMAS;
+	static const size_t sizeCleanBuffer = 2048000;
 	std::unique_ptr<std::uint64_t> buffer(new std::uint64_t[sizeCleanBuffer]);
 
 	size_t elementsToRead;

--- a/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
+++ b/src/main/c++/irioCoreCpp/terminals/impl/terminalsDMACommonImpl.cpp
@@ -102,31 +102,33 @@ std::uint16_t TerminalsDMACommonImpl::getNChImpl(const std::uint32_t n) const {
 	return m_nCh.at(n);
 }
 
-void TerminalsDMACommonImpl::startDMACommon(const std::uint32_t &dma) const {
-	// TODO: For the moment, do the same as in the old lib, reserve a lot of space
-	auto status = NiFpga_ConfigureFifo(m_session, dma, SIZE_HOST_DMAS);
+void TerminalsDMACommonImpl::startDMACommon(const std::uint32_t &dma,
+		const size_t depth) const {
+	auto status = NiFpga_ConfigureFifo(m_session, dma, depth);
 	utils::throwIfNotSuccessNiFpga(status,
-			"Error configuring " + m_nameTermDMA + std::to_string(dma));
+			"Error configuring " + m_nameTermDMA + std::to_string(dma) 
+			+ " with depth " + std::to_string(depth));
 	status = NiFpga_StartFifo(m_session, dma);
 	utils::throwIfNotSuccessNiFpga(status,
 			"Error starting " + m_nameTermDMA + std::to_string(dma));
 }
 
-void TerminalsDMACommonImpl::startDMAImpl(const std::uint32_t n) const {
+void TerminalsDMACommonImpl::startDMAImpl(const std::uint32_t n,
+		const size_t depth) const {
 	const auto it = m_mapDMA.find(n);
 	if (it == m_mapDMA.end()) {
 		const std::string err = std::to_string(n) + " is not a valid DMA";
 		throw errors::ResourceNotFoundError(err);
 	}
 
-	startDMACommon(it->second);
+	startDMACommon(it->second, depth);
 
 	cleanDMACommon(n);
 }
 
-void TerminalsDMACommonImpl::startAllDMAsImpl() const {
+void TerminalsDMACommonImpl::startAllDMAsImpl(const size_t depth) const {
 	for (const auto &values : m_mapDMA) {
-		startDMACommon(values.second);
+		startDMACommon(values.second, depth);
 	}
 
 	cleanAllDMAsImpl();

--- a/src/main/c++/irioCoreCpp/terminals/terminalsDMACommon.cpp
+++ b/src/main/c++/irioCoreCpp/terminals/terminalsDMACommon.cpp
@@ -19,12 +19,15 @@ std::uint16_t TerminalsDMACommon::getNCh(const std::uint32_t n) const {
 			->getNChImpl(n);
 }
 
-void TerminalsDMACommon::startDMA(const std::uint32_t n) const {
-	std::static_pointer_cast<TerminalsDMACommonImpl>(m_impl)->startDMAImpl(n);
+void TerminalsDMACommon::startDMA(const std::uint32_t n, 
+			const size_t depth) const {
+	std::static_pointer_cast<TerminalsDMACommonImpl>(m_impl)
+			->startDMAImpl(n, depth);
 }
 
-void TerminalsDMACommon::startAllDMAs() const {
-	std::static_pointer_cast<TerminalsDMACommonImpl>(m_impl)->startAllDMAsImpl();
+void TerminalsDMACommon::startAllDMAs(const size_t depth) const {
+	std::static_pointer_cast<TerminalsDMACommonImpl>(m_impl)
+			->startAllDMAsImpl(depth);
 }
 
 void TerminalsDMACommon::stopDMA(const std::uint32_t n) const {

--- a/src/main/c++/irioCoreCpp/terminals/terminalsDMACommon.cpp
+++ b/src/main/c++/irioCoreCpp/terminals/terminalsDMACommon.cpp
@@ -19,7 +19,7 @@ std::uint16_t TerminalsDMACommon::getNCh(const std::uint32_t n) const {
 			->getNChImpl(n);
 }
 
-void TerminalsDMACommon::startDMA(const std::uint32_t n, 
+void TerminalsDMACommon::startDMA(const std::uint32_t n,
 			const size_t depth) const {
 	std::static_pointer_cast<TerminalsDMACommonImpl>(m_impl)
 			->startDMAImpl(n, depth);


### PR DESCRIPTION
Previously the DMA depth value was hardcoded for legacy reasons as that was the number used in the original irioCore. Due to the scope of the project when developing irioCoreCpp, this debt was carried out and never fixed.

The addition of a optional parameter in the startDMA class specifying the depth allows specifying a depth while maintaining compatibility with previous projects that internally used the old hardcoded value.
